### PR TITLE
Add new primitive 'bigint' to Cbor.Decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.1.0 (unreleased)
+
+### Added
+
+#### Cbor
+
+- New data-type `Sign` to represent signed big integer values.
+
+#### Cbor.decode
+
+- New primitive `bigInt`:
+
+  ```elm
+  bigint : Decoder (Sign, Bytes)
+  ```
+
+### Changed
+
+N/A
+
+### Removed
+
+N/A
+
 ## v3.0.0 (2023-10-27)
 
 ### Changed

--- a/elm.json
+++ b/elm.json
@@ -18,6 +18,7 @@
     },
     "test-dependencies": {
         "elm/random": "1.0.0 <= v < 2.0.0",
-        "elm-explorations/test": "2.1.2 <= v < 3.0.0"
+        "elm-explorations/test": "2.1.2 <= v < 3.0.0",
+        "jxxcarlson/hex": "4.0.1 <= v < 5.0.0"
     }
 }

--- a/src/Cbor.elm
+++ b/src/Cbor.elm
@@ -1,8 +1,8 @@
-module Cbor exposing (CborItem(..))
+module Cbor exposing (CborItem(..), Sign(..))
 
 {-|
 
-@docs CborItem
+@docs CborItem, Sign
 
 -}
 
@@ -24,3 +24,11 @@ type CborItem
     | CborFloat Float
     | CborNull
     | CborUndefined
+
+
+{-| A sum-type for representing signs of integer numbers. By convention, 0 is
+always `Positive`.
+-}
+type Sign
+    = Positive
+    | Negative

--- a/src/Cbor/Decode.elm
+++ b/src/Cbor/Decode.elm
@@ -208,6 +208,9 @@ bigint =
         negative =
             D.map (\n -> ( Negative, n ))
 
+        -- Increment the bytes by +1
+        -- Adjust the bytes array size
+        increment : Bytes -> D.Decoder Bytes
         increment bs =
             let
                 width =

--- a/src/Cbor/Decode.elm
+++ b/src/Cbor/Decode.elm
@@ -302,7 +302,9 @@ bigint =
                                         runDecoder bytes |> positive
 
                                     NegativeBigNum ->
-                                        runDecoder bytes |> negative
+                                        runDecoder bytes
+                                            |> D.andThen increment
+                                            |> negative
 
                                     _ ->
                                         D.fail

--- a/tests/Cbor/DecodeTests.elm
+++ b/tests/Cbor/DecodeTests.elm
@@ -76,7 +76,7 @@ suite =
             , hex [ 0x39, 0xFF, 0xFF ]
                 |> expectBigInt Negative "0x00010000"
             , hex [ 0xC3, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]
-                |> expectBigInt Negative "0x010000000000000000"
+                |> expectBigInt Negative "0x010000000000000001"
             ]
         , describe "Major Type 2: a byte string"
             [ hex [ 0x40 ]


### PR DESCRIPTION
  This is needed for  mainly two reasons:

  - (a) As an easy way to decode tagged large integer values (tag 2 and 3).
      This is already possible via the `tagged` primitive, but this offers a
      nice shortcut.

  - (b) More importantly, this copes with values in the "unsafe" range >=
      2^63 and < -2^63. Because Elm ultimately relies on JavaScript as an
      execution engine, it inherits from the same pitfalls when it comes to
      numbers and in particular integer.

  As a consequence, we cannot decode these into actual `Int` numbers and
  we have to pick a target. Settling for a particular vendor library
  such as `cmditch/elm-bigint` or `dwayne/elm-natural` is unsatisfactory
  as it forces a dependency on end users for a primitives they might not
  even use.

  So we choose to export as big-endian byte sequence, which can then be
  turned into numbers of any of those libraries at the user's will.

  Co-authored-by: @mpizenberg