### PR TITLE
Add the oneOf decoder thanks to mpizenberg/elm-bytes-decoder

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,8 @@
     "dependencies": {
         "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
-        "elm-toulouse/float16": "1.0.0 <= v < 2.0.0"
+        "elm-toulouse/float16": "1.0.0 <= v < 2.0.0",
+        "mpizenberg/elm-bytes-decoder": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm/random": "1.0.0 <= v < 2.0.0",

--- a/src/Bytes/Decode/Floating.elm
+++ b/src/Bytes/Decode/Floating.elm
@@ -1,0 +1,104 @@
+module Bytes.Decode.Floating exposing (float16)
+
+{-| Extra Floating-point binary representation for Elm
+
+@docs float16
+
+-}
+
+import Bitwise exposing (and, or, shiftLeftBy, shiftRightBy)
+import Bytes exposing (Bytes, Endianness(..))
+import Bytes.Decode.Branchable as D
+import Bytes.Encode as E
+
+
+{-| Decode 2 bytes into a floating point number.
+-}
+float16 : Endianness -> D.Decoder Float
+float16 endian =
+    D.unsignedInt16 endian |> D.map (halfToFloat >> fromUnsignedInt32)
+
+
+
+{-------------------------------------------------------------------------------
+                                   Internals
+-------------------------------------------------------------------------------}
+
+
+{-| Convert a float16 representation (as an uint16) to a float32 representation
+
+       exponent
+              |        mantissa
+    sign      |               |
+       |      |               |
+       |      |               |
+       | /---------\/-------------------\
+       *  * * * * *  * * * * * * * * * *  (16-bit)
+
+    ------------------|-----------------------------------------
+    e in [1..30]      | h = (-1)^s * 2 ^ (e - 15) * 1.mmmmmmmmmm
+    e == 0 && m /= 0  | h = (-1)^s * 2 ^ -14 * 0.mmmmmmmmmm
+    e == 0 && m == 0  | h = +/- 0.0
+    e == 31 && m == 0 | h = +/- Infinity
+    e == 31 && m /= 0 | h = NaN
+
+Note that since we are converting from half-precision to single precision,
+there a gain in precision and some numbers may end up with more decimals in
+their float 32-bit representation (for instance: 65504.0 as 0xF97BFF, ends up
+as 65503.996723200005)
+
+-}
+halfToFloat : Int -> Int
+halfToFloat x =
+    let
+        s =
+            x |> shiftRightBy 15 |> and 1
+
+        e =
+            x |> shiftRightBy 10 |> and 0x1F
+
+        m =
+            x |> and 0x03FF
+    in
+    if e == 0 then
+        if m == 0 then
+            s |> shiftLeftBy 31
+
+        else
+            iEEE754 <| renormalize { s = s, e = e, m = m }
+
+    else if e == 31 then
+        iEEE754 { s = s, e = 255, m = m |> shiftLeftBy 13 }
+
+    else
+        iEEE754 { s = s, e = e + 112, m = m |> shiftLeftBy 13 }
+
+
+{-| De-normalize mantissa and then, renormalize it
+-}
+renormalize : { s : Int, e : Int, m : Int } -> { s : Int, e : Int, m : Int }
+renormalize { s, e, m } =
+    case m |> and 0x0400 of
+        0 ->
+            renormalize { s = s, e = e - 1, m = m |> shiftLeftBy 1 }
+
+        _ ->
+            { s = s, e = e + 113, m = m |> and -1025 }
+
+
+{-| Leverage existing float32 decoder to _cast_ a unsigned int32 into a 'Float'
+-}
+fromUnsignedInt32 : Int -> Float
+fromUnsignedInt32 =
+    E.unsignedInt32 BE
+        >> E.encode
+        >> D.decode (D.float32 BE)
+        >> Maybe.withDefault (0 / 0)
+
+
+{-| Recompose a IEEE754 encoding with sign, exponent and mantissa into
+a single number representing a floating number on 32 bytes.
+-}
+iEEE754 : { s : Int, e : Int, m : Int } -> Int
+iEEE754 { s, e, m } =
+    (s |> shiftLeftBy 31) |> or (e |> shiftLeftBy 23) |> or m

--- a/src/Cbor/Decode.elm
+++ b/src/Cbor/Decode.elm
@@ -59,9 +59,10 @@ MessagePack.
 
 import Bitwise exposing (and, shiftLeftBy, shiftRightBy)
 import Bytes exposing (Bytes, Endianness(..))
-import Bytes.Decode as D
+import Bytes.Decode
+import Bytes.Decode.Branchable as D
+import Bytes.Decode.Floating as D
 import Bytes.Encode as E
-import Bytes.Floating.Decode as D
 import Cbor exposing (CborItem(..))
 import Cbor.Encode as CE
 import Cbor.Tag exposing (Tag(..))
@@ -231,14 +232,14 @@ chunks majorType chunk mappend =
                             es
                                 |> List.reverse
                                 |> mappend
-                                |> D.Done
+                                |> Bytes.Decode.Done
                                 |> D.succeed
 
                         else
                             payloadForMajor majorType a
                                 |> D.andThen unsigned
                                 |> D.andThen chunk
-                                |> D.map (\e -> D.Loop (e :: es))
+                                |> D.map (\e -> Bytes.Decode.Loop (e :: es))
                     )
     in
     consumeNextMajor majorType <|
@@ -332,22 +333,22 @@ foldable majorType consumeNext processNext =
                         if a == tBREAK then
                             es
                                 |> List.reverse
-                                |> D.Done
+                                |> Bytes.Decode.Done
                                 |> D.succeed
 
                         else
                             processNext a
-                                |> D.map (\e -> D.Loop (e :: es))
+                                |> D.map (\e -> Bytes.Decode.Loop (e :: es))
                     )
 
         def ( n, es ) =
             if n <= 0 then
-                es |> List.reverse |> D.Done |> D.succeed
+                es |> List.reverse |> Bytes.Decode.Done |> D.succeed
 
             else
                 consumeNext
                     |> D.andThen processNext
-                    |> D.map (\e -> D.Loop ( n - 1, e :: es ))
+                    |> D.map (\e -> Bytes.Decode.Loop ( n - 1, e :: es ))
     in
     consumeNextMajor majorType <|
         \a ->

--- a/tests/Cbor/DecodeTests.elm
+++ b/tests/Cbor/DecodeTests.elm
@@ -442,7 +442,22 @@ suite =
             , hex [ 0x9F, 0x0E, 0xF5, 0x19, 0x05, 0x39, 0x00, 0xF5 ]
                 |> expect decodeFooTuple Nothing
             ]
+        , let
+            intOrString =
+                oneOf [ map IntVariant int, map StringVariant string ]
+          in
+          describe "oneOf"
+            [ hex [ 0x0E ]
+                |> expect intOrString (Just <| IntVariant 14)
+            , hex [ 0x64, 0xF0, 0x9F, 0x8C, 0x88 ]
+                |> expect intOrString (Just <| StringVariant "🌈")
+            ]
         ]
+
+
+type IntOrString
+    = IntVariant Int
+    | StringVariant String
 
 
 {-| Alias / Shortcut to write test cases


### PR DESCRIPTION
This PR shows how replacing elm/bytes module `Bytes.Decoder` by mpizenberg/elm-bytes-decoder module `Bytes.Decoder.Branchable` enables the addition of the `oneOf` combinator.

For decoding bytes, `oneOf` is usually to be avoided, but in certain situations where the only way to decode data is the eager way, we need a backtracking/branching mechanism. This is what `oneOf` enables.

Remark that for the sake of showing that things work, I did not update the Float16 package and instead vendored it with its type updated to `Bytes.Decoder.Branchable`. This would need to be properly changed.