### PR TITLE
Peek the first byte in oneOf

### DIFF
--- a/src/Bytes/Decode/Branchable.elm
+++ b/src/Bytes/Decode/Branchable.elm
@@ -7,7 +7,7 @@ module Bytes.Decode.Branchable exposing
     , bytes
     , map, map2, map3, map4, map5
     , keep, ignore, skip
-    , andThen, oneOf, repeat, loop
+    , andThen, oneOf, repeat, loop, peek
     )
 
 {-| Parse `Bytes` with custom error reporting and context tracking.
@@ -58,7 +58,7 @@ module Bytes.Decode.Branchable exposing
 
 # Advanced decoders
 
-@docs andThen, oneOf, repeat, loop
+@docs andThen, oneOf, repeat, loop, peek
 
 -}
 
@@ -484,6 +484,13 @@ loop initialState callback =
 
 
 -- Basics
+
+
+{-| Decode one byte into an integer from 0 to 255, but does not make progress in the bytes decoded.
+-}
+peek : Decoder Int
+peek =
+    fromDecoder D.unsignedInt8 0
 
 
 {-| Decode one byte into an integer from 0 to 255.

--- a/src/Cbor/Decode.elm
+++ b/src/Cbor/Decode.elm
@@ -1337,7 +1337,7 @@ oneOf alternatives =
         absurd =
             shiftLeftBy 5 28
     in
-    Decoder (D.succeed absurd) <|
+    Decoder (D.oneOf [ D.peek, D.succeed absurd ]) <|
         (alternatives
             |> List.map runDecoder
             |> D.oneOf

--- a/tests/Cbor/DecodeTests.elm
+++ b/tests/Cbor/DecodeTests.elm
@@ -237,6 +237,10 @@ suite =
             , hex [ 0xF9, 0xFF, 0xFF ]
                 |> expect (map isNaN float) (Just True)
             ]
+        , describe "Extras maybe(oneOf)"
+            [ hex [ 0xF6 ]
+                |> expect (maybe (oneOf [ bool, bool ])) (Just Nothing)
+            ]
         , describe "Extras"
             [ hex [ 0xF6 ]
                 |> expect (maybe bool) (Just Nothing)


### PR DESCRIPTION
In order to correctly pass the first byte to the parent decoder of `oneOf` such as the `maybe` decoder, we need to peek at it without making progress on the bytes decoded.